### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Helm install chart
         id: helm_install
         run: |
-          helm upgrade --install static --namespace=default . -f ./values.yaml
+          helm upgrade --install static --namespace=default . -f ./values.yaml --set autoscaling.enabled=false --set replicaCount=4
 
       - name: Deployment check rollout
         id: check_rollout

--- a/values.yaml
+++ b/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 2
+replicaCount: 2 # If autoscaling set this will not be exact as offloading to autoscaler
 
 image:
   repository: mcdermg/gary-nginx


### PR DESCRIPTION
Fix issue that pod/pods not there as offloading to autoscaler. We override the values yaml with specifics for just the GH action kind test with cli flags to ensure that its testing the rollout correctly. Otherwise its only single pod, then the autoscaling is building up to the min pod value but at the point we run the deployment check its only a single pod so means that the test is not really distributing over the nodes via labels. This will fix this as its been present for quite some time and was confusing me.